### PR TITLE
Added InfluxDB and Grafana to Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3.9"
-services: #What services should be run with influxdb?
+services: 
+    cea-os:
+        build: . #builds image from Dockerfile in current directory
+
     influxdb:
         image: influxdb
         ports:
@@ -19,7 +22,7 @@ services: #What services should be run with influxdb?
             - INFLUXDB_ADMIN_USER=admin
             - INFLUXDB_ADMIN_PASSWORD=password
     
-    grafana: #I think Grafana should be the other container/service in this Compose
+    grafana: 
         image: grafana/grafana
         ports:
             - 3000:3000 #grafana port
@@ -32,15 +35,6 @@ services: #What services should be run with influxdb?
             - grafana_data:/var/lib/grafana #create Docker volume called "grafana_data"
         depends_on:
             - influxdb
-        
-    #Not sure if loggers, objects, sensors are part of this Compose
-
-    # loggers: #loggers service uses image built from Dockerfile in current dir
-    #     build: ./cea-os/loggers
-    #     ports: #map to same port where our logger application is listening (connect host to container port)
-    #         - 5000:5000
-    #     volumes: #not sure if/where to mount data
-    # repeat above for objects and sensors?
 
 networks:
     grafana_network:


### PR DESCRIPTION
The Compose file now has two services: InfluxDB and Grafana. I included comments and questions within the file (definitely over-commented) about things I wasn't sure about (e.g. which other services to include, use of persistent data, etc).

I tested it out and it seems to work! To launch, I used command "docker-compose up -d" in CLI. This spun up two containers for InfluxDB and Grafana. I haven't done any further setup within these apps. Next steps might be to log into Grafana and connect it to a data source (InfluxDB) - I am clueless about this. 

Tutorial used: https://www.youtube.com/watch?v=rRKDfU4tmJQ